### PR TITLE
Added option to define bytes to copy from request to response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.github.hi-fi</groupId>
 	<artifactId>tcp-mocker-server</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.2</version>
 	<name>tcp-mocker-server</name>
 	<description>Test server to proxy and mock dependencies in testing.	</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.github.hi-fi</groupId>
 	<artifactId>tcp-mocker-server</artifactId>
-	<version>0.0.2</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<name>tcp-mocker-server</name>
 	<description>Test server to proxy and mock dependencies in testing.	</description>
 

--- a/src/main/java/com/github/hi_fi/tcpMockeServer/model/Mock.java
+++ b/src/main/java/com/github/hi_fi/tcpMockeServer/model/Mock.java
@@ -14,7 +14,8 @@ public class Mock {
 	private String fieldsToClear = "";
 	private String regexpFilters = "";
 	private String messageStarter = "";
-	private String bytesToClear = "";
+    //List of byte locations (in byte array) that needs to be copied from request to response in case of cached response is used.
+	private String bytesToCopy = "";
 	private Type endpointType = Type.TCP;
 	private String mockBeanName = null;
 	


### PR DESCRIPTION
- When returning cached response, but response needs to contain some identifier from request